### PR TITLE
Remove unnecesary log lines.

### DIFF
--- a/app/models/surveys_notifier.rb
+++ b/app/models/surveys_notifier.rb
@@ -7,8 +7,6 @@ class SurveysNotifier < ActiveRecord::Base
     issue = Issue.find(issueId)
 
     journal.details.each do |j|
-      ::Rails.logger.info("key " + j.prop_key)
-      ::Rails.logger.info("value " + j.value)
       if j.prop_key == "status_id" and issue.status.is_closed then
         self.manage_survey(issue)
       end


### PR DESCRIPTION
The line with `j.value` sometimes causes exceptions in redmine making redmine crash and a whole issue update gets lost.