### PR TITLE
Fixed a TypeError when a custom field was an array instead of a string.

### DIFF
--- a/app/models/surveys_notifier.rb
+++ b/app/models/surveys_notifier.rb
@@ -28,7 +28,8 @@ private
     pi_email = ""
 
     issue.custom_field_values.each do |field|
-      ::Rails.logger.info("custom field " + field.custom_field.name + " " + field.value)
+      field_value = field.value.is_a?(Array) ? field.value.join(', ') : field.value.to_s
+      ::Rails.logger.info("custom field #{field.custom_field.name}: #{field_value}")
       if field.custom_field.name == 'Principal Investigator' then
         pi_name = field.value
       elsif field.custom_field.name == 'PI e-mail' then


### PR DESCRIPTION
The logger line crashed when trying to concatenate strings and an array, if `field.value` is an array. This fix adds a check if `field.value` is an array, and in that case joins the array with commas.

Another bug that is fixed by this is if `field.value` is `nil`, as the `to_s` function will convert it to an empty string. That was not handled before and resulted in a similar crash. This was only an issue when creating issues through the API, and is thus not seen that often. It was solved in the script that queried the API instead, so that it set all `nil` filends to `""` before posting.